### PR TITLE
Make <paper-menu-button>.dropdown-trigger keyboard accessible

### DIFF
--- a/paper-menu-button.html
+++ b/paper-menu-button.html
@@ -96,7 +96,7 @@ Custom property | Description | Default
     }
   </style>
   <template>
-    <div id="trigger" on-tap="open">
+    <div id="trigger" on-click="open">
       <content select=".dropdown-trigger"></content>
     </div>
     <iron-dropdown


### PR DESCRIPTION
In the common case that `.dropdown-trigger` is in the tab order, e.g.,
```html
<paper-menu-button>
  <paper-icon-button icon="menu" class="dropdown-trigger"></paper-icon-button>
  <!-- menu goes here -->
</paper-menu-button>
```
allow a synthetic `'click' ` to open the dropdown (i.e. focused + Enter, hopefully on tap as well).