### PR TITLE
add option to prevent auto-closing on item activation

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -83,6 +83,22 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     <div class="horizontal-section-container">
       <div>
+        <h4>Paper Menu with multi selection</h4>
+        <div class="horizontal-section">
+          <paper-menu-button ignore-activate>
+            <paper-icon-button icon="menu" class="dropdown-trigger"></paper-icon-button>
+            <paper-menu class="dropdown-content" multi>
+              <template is="dom-repeat" items="[[letters]]" as="letter">
+                <paper-item>[[letter]]</paper-item>
+              </template>
+            </paper-menu>
+          </paper-menu-button>
+        </div>
+      </div>
+    </div>
+
+    <div class="horizontal-section-container">
+      <div>
         <h4>Disabled</h4>
         <div class="horizontal-section">
           <paper-menu-button disabled>

--- a/paper-menu-button.html
+++ b/paper-menu-button.html
@@ -202,6 +202,15 @@ Custom property | Description | Default
         },
 
         /**
+         * Set to true to disable automatically closing the dropdown after
+         * a selection has been made.
+         */
+        ignoreActivate: {
+          type: Boolean,
+          value: false
+        },
+
+        /**
          * An animation config. If provided, this will be used to animate the
          * opening of the dropdown.
          */
@@ -298,7 +307,9 @@ Custom property | Description | Default
        * set to `"iron-activate"`.
        */
       _onIronActivate: function(event) {
-        this.close();
+        if (!this.ignoreActivate) {
+          this.close();
+        }
       },
 
       /**
@@ -336,4 +347,3 @@ Custom property | Description | Default
     Polymer.PaperMenuButton = PaperMenuButton;
   })();
 </script>
-


### PR DESCRIPTION
The use case for this is multi-selecting items. Or having crazy content (like tabs and pages) in there, where not every activation is an item selection. But really just multi-selecting items. :balloon: 

@cdata PTAL