### PR TITLE
Adding elevation property to configure paper-material

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -159,6 +159,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </div>
       </div>
     </div>
+
+    <div class="horizontal-section-container">
+      <div>
+        <h4>Paper Menu Button with elevation</h4>
+        <div class="horizontal-section">
+          <paper-menu-button elevation="5">
+            <paper-icon-button icon="menu" class="dropdown-trigger" alt="menu"></paper-icon-button>
+            <paper-menu class="dropdown-content">
+              <template is="dom-repeat" items="[[letters]]" as="letter">
+                <paper-item>[[letter]]</paper-item>
+              </template>
+            </paper-menu>
+          </paper-menu-button>
+        </div>
+      </div>
+    </div>
+
   </template>
 
   <script>

--- a/paper-menu-button.html
+++ b/paper-menu-button.html
@@ -112,7 +112,7 @@ Custom property | Description | Default
       close-animation-config="[[closeAnimationConfig]]"
       no-animations="[[noAnimations]]"
       focus-target="[[_dropdownContent]]">
-      <paper-material class="dropdown-content">
+      <paper-material elevation="[[elevation]]" class="dropdown-content">
         <content id="content" select=".dropdown-content"></content>
       </paper-material>
     </iron-dropdown>
@@ -194,6 +194,21 @@ Custom property | Description | Default
           type: Number,
           value: 0,
           notify: true
+        },
+
+        /**
+         * The z-depth of the `dropdown-content`, from 0-5. Setting to 0 will remove the
+         * shadow, and each increasing number greater than 0 will be "deeper"
+         * than the last.
+         *
+         * @attribute elevation
+         * @type number
+         * @default 1
+         */
+        elevation: {
+          type: Number,
+          reflectToAttribute: true,
+          value: 1
         },
 
         /**


### PR DESCRIPTION
Currently it is not possible to change the elevation of the `<paper-material>` with style or custom css properties. This PR adds the elevation property of the `<paper-material>` element to the `<paper-menu-button>` element. In addition a demo of the elevation feature is added.