### PR TITLE
Add ANIMATION params to separate config, fixes #16

### DIFF
--- a/paper-menu-button.html
+++ b/paper-menu-button.html
@@ -129,6 +129,11 @@ Custom property | Description | Default
     (function() {
       'use strict';
 
+      var config = {
+        ANIMATION_CUBIC_BEZIER: 'cubic-bezier(.3,.95,.5,1)',
+        MAX_ANIMATION_TIME_MS: 400
+      };
+
       var PaperMenuButton = Polymer({
         is: 'paper-menu-button',
 
@@ -238,14 +243,14 @@ Custom property | Description | Default
                 timing: {
                   delay: 100,
                   duration: 150,
-                  easing: PaperMenuButton.ANIMATION_CUBIC_BEZIER
+                  easing: config.ANIMATION_CUBIC_BEZIER
                 }
               }, {
                 name: 'paper-menu-grow-height-animation',
                 timing: {
                   delay: 100,
                   duration: 275,
-                  easing: PaperMenuButton.ANIMATION_CUBIC_BEZIER
+                  easing: config.ANIMATION_CUBIC_BEZIER
                 }
               }];
             }
@@ -268,7 +273,7 @@ Custom property | Description | Default
                 timing: {
                   delay: 100,
                   duration: 50,
-                  easing: PaperMenuButton.ANIMATION_CUBIC_BEZIER
+                  easing: config.ANIMATION_CUBIC_BEZIER
                 }
               }, {
                 name: 'paper-menu-shrink-height-animation',
@@ -394,8 +399,9 @@ Custom property | Description | Default
         }
       });
 
-      PaperMenuButton.ANIMATION_CUBIC_BEZIER = 'cubic-bezier(.3,.95,.5,1)';
-      PaperMenuButton.MAX_ANIMATION_TIME_MS = 400;
+      Object.keys(config).forEach(function (key) {
+        PaperMenuButton[key] = config[key];
+      });
 
       Polymer.PaperMenuButton = PaperMenuButton;
     })();


### PR DESCRIPTION
This solves an issue where property evaluation happens before `PaperMenuButton` itself is defined. The original code is very weak because a variable is defined that consumes properties on that same variable which are defined afterwards.

The issue doesn't occur in regular Polymer cases but does after vulcanizing/uglifying code.

(added by @valdrin: fixes #16)