### PR TITLE
Add allow-outside-scroll property

### DIFF
--- a/paper-menu-button.html
+++ b/paper-menu-button.html
@@ -117,6 +117,7 @@ Custom property | Description | Default
       open-animation-config="[[openAnimationConfig]]"
       close-animation-config="[[closeAnimationConfig]]"
       no-animations="[[noAnimations]]"
+      allow-outside-scroll="[[allowOutsideScroll]]"
       focus-target="[[_dropdownContent]]">
       <paper-material class="dropdown-content">
         <content id="content" select=".dropdown-content"></content>
@@ -314,6 +315,17 @@ Custom property | Description | Default
           }
 
           this.$.dropdown.open();
+        },
+
+        /**
+         * By default, the dropdown will constrain scrolling on the page
+         * to itself when opened.
+         * Set to true in order to prevent scroll from being constrained
+         * to the dropdown when it opens.
+         */
+        allowOutsideScroll: {
+          type: Boolean,
+          value: false
         },
 
         /**


### PR DESCRIPTION
Adding an allow-scroll-lock property implemented in `iron-dropdown` [PR #25](https://github.com/PolymerElements/iron-dropdown/pull/25), to make it accessible in `paper-menu-button`. 

Re-opening https://github.com/PolymerElements/paper-menu-button/pull/35 post rebase. Pinging @cdata.