### PR TITLE
Update with proper Polymer license

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "type": "git",
     "url": "git://github.com/PolymerElements/paper-menu-button.git"
   },
-  "license": "MIT",
+  "license": "http://polymer.github.io/LICENSE.txt",
   "homepage": "https://github.com/PolymerElements/paper-menu-button",
   "dependencies": {
     "polymer": "Polymer/polymer#^1.1.0",


### PR DESCRIPTION
Fixes #41 by replacing MIT license with "http://polymer.github.io/LICENSE.txt"