### PR TITLE
Fixes paper-dropdown-menu#164: Adds `restore-focus-on-close` to the wrapped iron-dropdown.

### DIFF
--- a/paper-menu-button.html
+++ b/paper-menu-button.html
@@ -121,6 +121,7 @@ Custom property | Description | Default
       close-animation-config="[[closeAnimationConfig]]"
       no-animations="[[noAnimations]]"
       focus-target="[[_dropdownContent]]"
+      restore-focus-on-close
       on-iron-overlay-canceled="__onIronOverlayCanceled">
       <div class="dropdown-content">
         <content id="content" select=".dropdown-content"></content>


### PR DESCRIPTION
(fixes PolymerElements/paper-dropdown-menu#164)