### PR TITLE
Fixes #85: Adds `close-on-activate` property.

### DIFF
--- a/paper-menu-button.html
+++ b/paper-menu-button.html
@@ -231,6 +231,15 @@ Custom property | Description | Default
           },
 
           /**
+           * Set to true to enable automatically closing the dropdown after an
+           * item has been activated, even if the selection did not change.
+           */
+          closeOnActivate: {
+            type: Boolean,
+            value: false
+          },
+
+          /**
            * An animation config. If provided, this will be used to animate the
            * opening of the dropdown.
            */
@@ -305,6 +314,7 @@ Custom property | Description | Default
         },
 
         listeners: {
+          'iron-activate': '_onIronActivate',
           'iron-select': '_onIronSelect'
         },
 
@@ -365,6 +375,18 @@ Custom property | Description | Default
          */
         _onIronSelect: function(event) {
           if (!this.ignoreSelect) {
+            this.close();
+          }
+        },
+
+        /**
+         * Closes the dropdown when an `iron-activate` event is received if
+         * `closeOnActivate` is true.
+         *
+         * @param {CustomEvent} event A CustomEvent of type 'iron-activate'.
+         */
+        _onIronActivate: function(event) {
+          if (this.closeOnActivate) {
             this.close();
           }
         },

--- a/test/paper-menu-button.html
+++ b/test/paper-menu-button.html
@@ -107,6 +107,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         expect(menuButton.hasAttribute('aria-haspopup')).to.be.equal(true);
       });
 
+      test('closes on iron-activate if close-on-activate is true', function(done) {
+        menuButton.closeOnActivate = true;
+
+        menuButton.addEventListener('paper-dropdown-open', function() {
+          menuButton.addEventListener('paper-dropdown-close', function() {
+            done();
+          });
+
+          content.dispatchEvent(new CustomEvent('iron-activate', {
+            bubbles: true,
+            cancelable: true
+          }));
+        });
+
+        MockInteractions.tap(trigger);
+      });
+
     });
 
     suite('when there are two buttons', function() {


### PR DESCRIPTION
Setting `close-on-activate` causes the paper-menu-button to close its content when an `iron-activate` event bubbles to it.

Fixes #85, PolymerElements/paper-dropdown-menu#72.