### PR TITLE
Fixes #83: Expose `dynamicAlign`, `noOverlap`.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,6 +25,7 @@
     "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#^1.0.0",
     "iron-behaviors": "PolymerElements/iron-behaviors#^1.0.0",
     "iron-dropdown": "PolymerElements/iron-dropdown#^1.0.0",
+    "iron-fit-behavior": "PolymerElements/iron-fit-behavior#^1.2.0",
     "neon-animation": "PolymerElements/neon-animation#^1.0.0",
     "paper-styles": "PolymerElements/paper-styles#^1.0.0"
   },

--- a/paper-menu-button.html
+++ b/paper-menu-button.html
@@ -115,8 +115,10 @@ Custom property | Description | Default
       opened="{{opened}}"
       horizontal-align="[[horizontalAlign]]"
       vertical-align="[[verticalAlign]]"
+      dynamic-align="[[dynamicAlign]]"
       horizontal-offset="[[horizontalOffset]]"
       vertical-offset="[[verticalOffset]]"
+      no-overlap="[[noOverlap]]"
       open-animation-config="[[openAnimationConfig]]"
       close-animation-config="[[closeAnimationConfig]]"
       no-animations="[[noAnimations]]"
@@ -191,6 +193,16 @@ Custom property | Description | Default
           },
 
           /**
+           * If true, the `horizontalAlign` and `verticalAlign` properties will
+           * be considered preferences instead of strict requirements when
+           * positioning the dropdown and may be changed if doing so reduces
+           * the area of the dropdown falling outside of `fitInto`.
+           */
+          dynamicAlign: {
+            type: Boolean
+          },
+
+          /**
            * A pixel value that will be added to the position calculated for the
            * given `horizontalAlign`. Use a negative value to offset to the
            * left, or a positive value to offset to the right.
@@ -210,6 +222,14 @@ Custom property | Description | Default
             type: Number,
             value: 0,
             notify: true
+          },
+
+          /**
+           * If true, the dropdown will be positioned so that it doesn't overlap
+           * the button.
+           */
+          noOverlap: {
+            type: Boolean
           },
 
           /**


### PR DESCRIPTION
I don't think it makes sense to expose the others because they're all implied by their use in paper-menu-button but these two should definitely be exposed.

(Fixes #83.)