### PR TITLE
Prevent menu content from wrapping by default. Fixes #56.

### DIFF
--- a/paper-menu-button.html
+++ b/paper-menu-button.html
@@ -93,6 +93,11 @@ Custom property | Description | Default
         @apply(--paper-menu-button-content);
       }
 
+      .dropdown-content ::content > * {
+        /* Ensure items are full width so they don't wrap during animation. */
+        white-space: nowrap;
+      }
+
       :host([vertical-align="top"]) .dropdown-content {
         margin-bottom: 20px;
         margin-top: -10px;
@@ -126,7 +131,7 @@ Custom property | Description | Default
       allow-outside-scroll="[[allowOutsideScroll]]"
       restore-focus-on-close="[[restoreFocusOnClose]]"
       on-iron-overlay-canceled="__onIronOverlayCanceled">
-      <div class="dropdown-content">
+      <div id="contentWrapper" class="dropdown-content">
         <content id="content" select=".dropdown-content"></content>
       </div>
     </iron-dropdown>


### PR DESCRIPTION
By turning off wrapping, items don't reflow during menu animation.

Note that, while most people will probably welcome this change, there's some risk that people have created dropdown menus that rely on wrapping.

This PR currently doesn't include a unit test, since it's exclusively styling, but let me know if one should be added. Along those same lines, I'd like to provide an update to the original repro case provided so that people can verify the fix. I had difficulty creating a jsBin that imported `paper-menu-button.html` off this fork, but imported all other dependencies off of polygit. If there's an easy way to do that, please let me know and I'll post an updated repro.