### PR TITLE
Change the cursor back to the default cursor

### DIFF
--- a/paper-menu-button.html
+++ b/paper-menu-button.html
@@ -80,6 +80,7 @@ Custom property | Description | Default
       }
 
       iron-dropdown {
+        cursor: auto;
         @apply(--paper-menu-button-dropdown);
       }
 

--- a/paper-menu-button.html
+++ b/paper-menu-button.html
@@ -80,7 +80,6 @@ Custom property | Description | Default
       }
 
       iron-dropdown {
-        cursor: auto;
         @apply(--paper-menu-button-dropdown);
       }
 
@@ -104,6 +103,10 @@ Custom property | Description | Default
         bottom: 10px;
         margin-bottom: -10px;
         margin-top: 20px;
+      }
+      
+      #trigger {
+        cursor: pointer;
       }
     </style>
 


### PR DESCRIPTION
Change the cursor back to the arrow (default) cursor from the hand (pointer) cursor set in in the paper-dropdown-menu.

Fixes #103