### PR TITLE
Remove deprecated neon animation, use CSS keyframe animations

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,7 @@
     "iron-behaviors": "PolymerElements/iron-behaviors#1 - 2",
     "iron-dropdown": "PolymerElements/iron-dropdown#no-neon-animation",
     "iron-fit-behavior": "PolymerElements/iron-fit-behavior#1 - 2",
+    "neon-animation": "PolymerElements/neon-animation#1 - 2",
     "paper-styles": "PolymerElements/paper-styles#1 - 2"
   },
   "devDependencies": {
@@ -50,6 +51,7 @@
         "iron-behaviors": "PolymerElements/iron-behaviors#^1.0.0",
         "iron-dropdown": "PolymerElements/iron-dropdown#no-neon-animation",
         "iron-fit-behavior": "PolymerElements/iron-fit-behavior#^1.2.0",
+        "neon-animation": "PolymerElements/neon-animation#^1.0.0",
         "paper-styles": "PolymerElements/paper-styles#^1.0.0"
       },
       "devDependencies": {

--- a/bower.json
+++ b/bower.json
@@ -24,9 +24,8 @@
     "polymer": "Polymer/polymer#1.9 - 2",
     "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#1 - 2",
     "iron-behaviors": "PolymerElements/iron-behaviors#1 - 2",
-    "iron-dropdown": "PolymerElements/iron-dropdown#1 - 2",
+    "iron-dropdown": "PolymerElements/iron-dropdown#no-neon-animation",
     "iron-fit-behavior": "PolymerElements/iron-fit-behavior#1 - 2",
-    "neon-animation": "PolymerElements/neon-animation#1 - 2",
     "paper-styles": "PolymerElements/paper-styles#1 - 2"
   },
   "devDependencies": {
@@ -41,8 +40,7 @@
     "paper-item": "PolymerElements/paper-item#1 - 2",
     "paper-listbox": "PolymerElements/paper-listbox#1 - 2",
     "web-component-tester": "^6.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0",
-    "web-animations-js": "web-animations/web-animations-js#^2.2"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0"
   },
   "variants": {
     "1.x": {
@@ -50,9 +48,8 @@
         "polymer": "Polymer/polymer#^1.9",
         "iron-a11y-keys-behavior": "PolymerElements/iron-a11y-keys-behavior#^1.0.0",
         "iron-behaviors": "PolymerElements/iron-behaviors#^1.0.0",
-        "iron-dropdown": "PolymerElements/iron-dropdown#^1.0.0",
+        "iron-dropdown": "PolymerElements/iron-dropdown#no-neon-animation",
         "iron-fit-behavior": "PolymerElements/iron-fit-behavior#^1.2.0",
-        "neon-animation": "PolymerElements/neon-animation#^1.0.0",
         "paper-styles": "PolymerElements/paper-styles#^1.0.0"
       },
       "devDependencies": {
@@ -67,8 +64,7 @@
         "paper-item": "PolymerElements/paper-item#^1.0.0",
         "paper-listbox": "PolymerElements/paper-listbox#^1.0.0",
         "web-component-tester": "^4.0.0",
-        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
-        "web-animations-js": "web-animations/web-animations-js#^2.2"
+        "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
       },
       "resolutions": {
         "webcomponentsjs": "^0.7"

--- a/demo/index.html
+++ b/demo/index.html
@@ -31,8 +31,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../../iron-demo-helpers/demo-snippet.html">
   <link rel="import" href="../../iron-demo-helpers/demo-pages-shared-styles.html">
 
-  <!-- Ensure Web Animations polyfill is loaded since neon-animation 2.0 doesn't import it -->
-  <link rel="import" href="../../neon-animation/web-animations.html">
   <link rel="import" href="../paper-menu-button.html">
 
   <custom-style>

--- a/paper-menu-button-animations.d.ts
+++ b/paper-menu-button-animations.d.ts
@@ -9,7 +9,6 @@
  */
 
 /// <reference path="../polymer/types/polymer.d.ts" />
-/// <reference path="../neon-animation/neon-animation-behavior.d.ts" />
 
 interface PaperMenuGrowHeightAnimationElement extends Polymer.Element, Polymer.NeonAnimationBehavior {
   configure(config: any): any;

--- a/paper-menu-button-animations.d.ts
+++ b/paper-menu-button-animations.d.ts
@@ -9,6 +9,7 @@
  */
 
 /// <reference path="../polymer/types/polymer.d.ts" />
+/// <reference path="../neon-animation/neon-animation-behavior.d.ts" />
 
 interface PaperMenuGrowHeightAnimationElement extends Polymer.Element, Polymer.NeonAnimationBehavior {
   configure(config: any): any;

--- a/paper-menu-button.d.ts
+++ b/paper-menu-button.d.ts
@@ -12,11 +12,8 @@
 /// <reference path="../iron-a11y-keys-behavior/iron-a11y-keys-behavior.d.ts" />
 /// <reference path="../iron-behaviors/iron-control-state.d.ts" />
 /// <reference path="../iron-dropdown/iron-dropdown.d.ts" />
-/// <reference path="../neon-animation/animations/fade-in-animation.d.ts" />
-/// <reference path="../neon-animation/animations/fade-out-animation.d.ts" />
 /// <reference path="../paper-styles/default-theme.d.ts" />
 /// <reference path="../paper-styles/shadow.d.ts" />
-/// <reference path="paper-menu-button-animations.d.ts" />
 
 /**
  * Material design: [Dropdown buttons](https://www.google.com/design/spec/components/buttons.html#buttons-dropdown-buttons)
@@ -120,18 +117,6 @@ declare class PaperMenuButton extends Polymer.Element {
    * item has been activated, even if the selection did not change.
    */
   closeOnActivate: boolean|null|undefined;
-
-  /**
-   * An animation config. If provided, this will be used to animate the
-   * opening of the dropdown.
-   */
-  openAnimationConfig: object|null|undefined;
-
-  /**
-   * An animation config. If provided, this will be used to animate the
-   * closing of the dropdown.
-   */
-  closeAnimationConfig: object|null|undefined;
 
   /**
    * By default, the dropdown will constrain scrolling on the page

--- a/paper-menu-button.d.ts
+++ b/paper-menu-button.d.ts
@@ -119,16 +119,6 @@ declare class PaperMenuButton extends Polymer.Element {
   closeOnActivate: boolean|null|undefined;
 
   /**
-   * This property is deprecated and will be ignored.
-   */
-  openAnimationConfig: object|null|undefined;
-
-  /**
-   * This property is deprecated and will be ignored.
-   */
-  closeAnimationConfig: object|null|undefined;
-
-  /**
    * By default, the dropdown will constrain scrolling on the page
    * to itself when opened.
    * Set to true in order to prevent scroll from being constrained

--- a/paper-menu-button.d.ts
+++ b/paper-menu-button.d.ts
@@ -119,6 +119,16 @@ declare class PaperMenuButton extends Polymer.Element {
   closeOnActivate: boolean|null|undefined;
 
   /**
+   * This property is deprecated and will be ignored.
+   */
+  openAnimationConfig: object|null|undefined;
+
+  /**
+   * This property is deprecated and will be ignored.
+   */
+  closeAnimationConfig: object|null|undefined;
+
+  /**
    * By default, the dropdown will constrain scrolling on the page
    * to itself when opened.
    * Set to true in order to prevent scroll from being constrained

--- a/paper-menu-button.html
+++ b/paper-menu-button.html
@@ -104,24 +104,24 @@ Custom property | Description | Default
 
       .entry-animation {
         animation-delay: 100ms;
-        animation-duration: 250ms;
+        animation-duration: 275ms;
         animation-name: expand-animation;
       }
 
-      .entry-animation>* {
+      .entry-animation > * {
         animation-delay: 100ms;
-        animation-duration: 250ms;
+        animation-duration: 275ms;
         animation-name: expand-animationInverse;
       }
 
       .exit-animation {
-        animation-duration: 150ms;
+        animation-duration: 200ms;
         animation-name: expand-animation;
         animation-direction: reverse;
       }
 
-      .exit-animation>* {
-        animation-duration: 150ms;
+      .exit-animation > * {
+        animation-duration: 200ms;
         animation-name: expand-animationInverse;
         animation-direction: reverse;
       }
@@ -132,47 +132,51 @@ Custom property | Description | Default
           transform: scale(0.7, 0.5);
         }
         6.25% {
-          opacity: 0.2;
+          opacity: 0.09;
           transform: scale(0.75669, 0.59448);
         }
         12.5% {
-          opacity: 0.3;
+          opacity: 0.17;
           transform: scale(0.80741, 0.67902);
         }
         18.75% {
-          opacity: 0.4;
+          opacity: 0.27;
           transform: scale(0.85146, 0.75243);
         }
         25% {
-          opacity: 0.6;
+          opacity: 0.36;
           transform: scale(0.88846, 0.8141);
         }
         31.25% {
-          opacity: 0.7;
+          opacity: 0.25;
           transform: scale(0.91851, 0.86418);
         }
         37.5% {
-          opacity: 0.8;
+          opacity: 0.5;
           transform: scale(0.9421, 0.90351);
         }
         43.75% {
-          opacity: 0.9;
+          opacity: 0.58;
           transform: scale(0.96006, 0.93343);
         }
         50% {
-          opacity: 1;
+          opacity: 0.67;
           transform: scale(0.97333, 0.95555);
         }
         56.25% {
+          opacity: 0.75;
           transform: scale(0.98285, 0.97142);
         }
         62.5% {
+          opacity: 0.83;
           transform: scale(0.98949, 0.98248);
         }
         68.75% {
+          opacity: 0.82;
           transform: scale(0.99395, 0.98992);
         }
         75% {
+          opacity: 1;
           transform: scale(0.99682, 0.9947);
         }
         81.25% {
@@ -249,10 +253,22 @@ Custom property | Description | Default
       <slot name="dropdown-trigger"></slot>
     </div>
 
-    <iron-dropdown id="dropdown" opened="{{opened}}" horizontal-align="[[horizontalAlign]]" vertical-align="[[verticalAlign]]"
-      dynamic-align="[[dynamicAlign]]" horizontal-offset="[[horizontalOffset]]" vertical-offset="[[verticalOffset]]" no-overlap="[[noOverlap]]"
-      entry-animation="entry-animation" exit-animation="exit-animation" no-animations="[[noAnimations]]" focus-target="[[_dropdownContent]]"
-      allow-outside-scroll="[[allowOutsideScroll]]" restore-focus-on-close="[[restoreFocusOnClose]]" on-iron-overlay-canceled="__onIronOverlayCanceled">
+    <iron-dropdown
+      id="dropdown"
+      opened="{{opened}}"
+      horizontal-align="[[horizontalAlign]]"
+      vertical-align="[[verticalAlign]]"
+      dynamic-align="[[dynamicAlign]]"
+      horizontal-offset="[[horizontalOffset]]"
+      vertical-offset="[[verticalOffset]]"
+      no-overlap="[[noOverlap]]"
+      entry-animation="entry-animation"
+      exit-animation="exit-animation"
+      no-animations="[[noAnimations]]"
+      focus-target="[[_dropdownContent]]"
+      allow-outside-scroll="[[allowOutsideScroll]]"
+      restore-focus-on-close="[[restoreFocusOnClose]]"
+      on-iron-overlay-canceled="__onIronOverlayCanceled">
       <div slot="dropdown-content" class="dropdown-content">
         <slot id="content" name="dropdown-content"></slot>
       </div>
@@ -379,6 +395,28 @@ Custom property | Description | Default
           closeOnActivate: {
             type: Boolean,
             value: false
+          },
+
+          /**
+           * This property is deprecated and will be ignored.
+           * @deprecated
+           */
+          openAnimationConfig: {
+            type: Object,
+            value: function() {
+              return [];
+            }
+          },
+
+          /**
+           * This property is deprecated and will be ignored.
+           * @deprecated
+           */
+          closeAnimationConfig: {
+            type: Object,
+            value: function() {
+              return [];
+            }
           },
 
           /**

--- a/paper-menu-button.html
+++ b/paper-menu-button.html
@@ -12,11 +12,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <link rel="import" href="../iron-a11y-keys-behavior/iron-a11y-keys-behavior.html">
 <link rel="import" href="../iron-behaviors/iron-control-state.html">
 <link rel="import" href="../iron-dropdown/iron-dropdown.html">
-<link rel="import" href="../neon-animation/animations/fade-in-animation.html">
-<link rel="import" href="../neon-animation/animations/fade-out-animation.html">
 <link rel="import" href="../paper-styles/default-theme.html">
 <link rel="import" href="../paper-styles/shadow.html">
-<link rel="import" href="paper-menu-button-animations.html">
 
 <!--
 Material design: [Dropdown buttons](https://www.google.com/design/spec/components/buttons.html#buttons-dropdown-buttons)
@@ -80,56 +77,182 @@ Custom property | Description | Default
       }
 
       iron-dropdown {
+        border-radius: 2px;
+        @apply --shadow-elevation-2dp;
         @apply --paper-menu-button-dropdown;
       }
 
       .dropdown-content {
-        @apply --shadow-elevation-2dp;
-
         position: relative;
-        border-radius: 2px;
         background-color: var(--paper-menu-button-dropdown-background, var(--primary-background-color));
 
         @apply --paper-menu-button-content;
       }
 
-      :host([vertical-align="top"]) .dropdown-content {
-        margin-bottom: 20px;
-        margin-top: -10px;
-        top: 10px;
-      }
-
-      :host([vertical-align="bottom"]) .dropdown-content {
-        bottom: 10px;
-        margin-bottom: -10px;
-        margin-top: 20px;
-      }
-
       #trigger {
         cursor: pointer;
       }
+
+      .animating,
+      .animating > * {
+        overflow: hidden;
+        will-change: transform;
+        contain: content;
+        animation-fill-mode: both;
+        animation-timing-function: step-end;
+      }
+
+      .entry-animation {
+        animation-delay: 100ms;
+        animation-duration: 250ms;
+        animation-name: expand-animation;
+      }
+
+      .entry-animation>* {
+        animation-delay: 100ms;
+        animation-duration: 250ms;
+        animation-name: expand-animationInverse;
+      }
+
+      .exit-animation {
+        animation-duration: 150ms;
+        animation-name: expand-animation;
+        animation-direction: reverse;
+      }
+
+      .exit-animation>* {
+        animation-duration: 150ms;
+        animation-name: expand-animationInverse;
+        animation-direction: reverse;
+      }
+
+      @keyframes expand-animation {
+        0% {
+          opacity: 0;
+          transform: scale(0.7, 0.5);
+        }
+        6.25% {
+          opacity: 0.2;
+          transform: scale(0.75669, 0.59448);
+        }
+        12.5% {
+          opacity: 0.3;
+          transform: scale(0.80741, 0.67902);
+        }
+        18.75% {
+          opacity: 0.4;
+          transform: scale(0.85146, 0.75243);
+        }
+        25% {
+          opacity: 0.6;
+          transform: scale(0.88846, 0.8141);
+        }
+        31.25% {
+          opacity: 0.7;
+          transform: scale(0.91851, 0.86418);
+        }
+        37.5% {
+          opacity: 0.8;
+          transform: scale(0.9421, 0.90351);
+        }
+        43.75% {
+          opacity: 0.9;
+          transform: scale(0.96006, 0.93343);
+        }
+        50% {
+          opacity: 1;
+          transform: scale(0.97333, 0.95555);
+        }
+        56.25% {
+          transform: scale(0.98285, 0.97142);
+        }
+        62.5% {
+          transform: scale(0.98949, 0.98248);
+        }
+        68.75% {
+          transform: scale(0.99395, 0.98992);
+        }
+        75% {
+          transform: scale(0.99682, 0.9947);
+        }
+        81.25% {
+          transform: scale(0.99854, 0.99757);
+        }
+        87.5% {
+          transform: scale(0.99948, 0.99913);
+        }
+        93.75% {
+          transform: scale(0.9999, 0.99983);
+        }
+        100% {
+          transform: scale(1, 1);
+        }
+      }
+
+      @keyframes expand-animationInverse {
+        0% {
+          transform: scale(1.42857, 2);
+        }
+        6.25% {
+          transform: scale(1.32155, 1.68214);
+        }
+        12.5% {
+          transform: scale(1.23853, 1.47271);
+        }
+        18.75% {
+          transform: scale(1.17445, 1.32903);
+        }
+        25% {
+          transform: scale(1.12554, 1.22835);
+        }
+        31.25% {
+          transform: scale(1.08872, 1.15717);
+        }
+        37.5% {
+          transform: scale(1.06146, 1.10679);
+        }
+        43.75% {
+          transform: scale(1.0416, 1.07132);
+        }
+        50% {
+          transform: scale(1.0274, 1.04652);
+        }
+        56.25% {
+          transform: scale(1.01745, 1.02942);
+        }
+        62.5% {
+          transform: scale(1.01062, 1.01783);
+        }
+        68.75% {
+          transform: scale(1.00609, 1.01018);
+        }
+        75% {
+          transform: scale(1.00319, 1.00533);
+        }
+        81.25% {
+          transform: scale(1.00146, 1.00244);
+        }
+        87.5% {
+          transform: scale(1.00052, 1.00087);
+        }
+        93.75% {
+          transform: scale(1.0001, 1.00017);
+        }
+        100% {
+          transform: scale(1, 1);
+        }
+      }
+
     </style>
 
     <div id="trigger" on-tap="toggle">
       <slot name="dropdown-trigger"></slot>
     </div>
 
-    <iron-dropdown
-      id="dropdown"
-      opened="{{opened}}"
-      horizontal-align="[[horizontalAlign]]"
-      vertical-align="[[verticalAlign]]"
-      dynamic-align="[[dynamicAlign]]"
-      horizontal-offset="[[horizontalOffset]]"
-      vertical-offset="[[verticalOffset]]"
-      no-overlap="[[noOverlap]]"
-      open-animation-config="[[openAnimationConfig]]"
-      close-animation-config="[[closeAnimationConfig]]"
-      no-animations="[[noAnimations]]"
-      focus-target="[[_dropdownContent]]"
-      allow-outside-scroll="[[allowOutsideScroll]]"
-      restore-focus-on-close="[[restoreFocusOnClose]]"
-      on-iron-overlay-canceled="__onIronOverlayCanceled">
+    <iron-dropdown id="dropdown" opened="{{opened}}" horizontal-align="[[horizontalAlign]]" vertical-align="[[verticalAlign]]"
+      dynamic-align="[[dynamicAlign]]" horizontal-offset="[[horizontalOffset]]" vertical-offset="[[verticalOffset]]" no-overlap="[[noOverlap]]"
+      entry-animation="entry-animation" exit-animation="exit-animation" no-animations="[[noAnimations]]" focus-target="[[_dropdownContent]]"
+      allow-outside-scroll="[[allowOutsideScroll]]" restore-focus-on-close="[[restoreFocusOnClose]]" on-iron-overlay-canceled="__onIronOverlayCanceled">
       <div slot="dropdown-content" class="dropdown-content">
         <slot id="content" name="dropdown-content"></slot>
       </div>
@@ -139,11 +262,6 @@ Custom property | Description | Default
   <script>
     (function() {
       'use strict';
-
-      var config = {
-        ANIMATION_CUBIC_BEZIER: 'cubic-bezier(.3,.95,.5,1)',
-        MAX_ANIMATION_TIME_MS: 400
-      };
 
       var PaperMenuButton = Polymer({
         is: 'paper-menu-button',
@@ -261,66 +379,6 @@ Custom property | Description | Default
           closeOnActivate: {
             type: Boolean,
             value: false
-          },
-
-          /**
-           * An animation config. If provided, this will be used to animate the
-           * opening of the dropdown.
-           */
-          openAnimationConfig: {
-            type: Object,
-            value: function() {
-              return [{
-                name: 'fade-in-animation',
-                timing: {
-                  delay: 100,
-                  duration: 200
-                }
-              }, {
-                name: 'paper-menu-grow-width-animation',
-                timing: {
-                  delay: 100,
-                  duration: 150,
-                  easing: config.ANIMATION_CUBIC_BEZIER
-                }
-              }, {
-                name: 'paper-menu-grow-height-animation',
-                timing: {
-                  delay: 100,
-                  duration: 275,
-                  easing: config.ANIMATION_CUBIC_BEZIER
-                }
-              }];
-            }
-          },
-
-          /**
-           * An animation config. If provided, this will be used to animate the
-           * closing of the dropdown.
-           */
-          closeAnimationConfig: {
-            type: Object,
-            value: function() {
-              return [{
-                name: 'fade-out-animation',
-                timing: {
-                  duration: 150
-                }
-              }, {
-                name: 'paper-menu-shrink-width-animation',
-                timing: {
-                  delay: 100,
-                  duration: 50,
-                  easing: config.ANIMATION_CUBIC_BEZIER
-                }
-              }, {
-                name: 'paper-menu-shrink-height-animation',
-                timing: {
-                  duration: 200,
-                  easing: 'ease-in'
-                }
-              }];
-            }
           },
 
           /**
@@ -473,10 +531,6 @@ Custom property | Description | Default
             event.preventDefault();
           }
         }
-      });
-
-      Object.keys(config).forEach(function (key) {
-        PaperMenuButton[key] = config[key];
       });
 
       Polymer.PaperMenuButton = PaperMenuButton;

--- a/paper-menu-button.html
+++ b/paper-menu-button.html
@@ -76,6 +76,10 @@ Custom property | Description | Default
         @apply --paper-menu-button-disabled;
       }
 
+      #trigger {
+        cursor: pointer;
+      }
+
       iron-dropdown {
         border-radius: 2px;
         @apply --shadow-elevation-2dp;
@@ -83,18 +87,16 @@ Custom property | Description | Default
       }
 
       .dropdown-content {
+        /* Inherits from iron-dropdown, so inverse animation can work as expected. */
+        transform-origin: inherit;
         position: relative;
         background-color: var(--paper-menu-button-dropdown-background, var(--primary-background-color));
 
         @apply --paper-menu-button-content;
       }
-
-      #trigger {
-        cursor: pointer;
-      }
-
+      
       .animating,
-      .animating > * {
+      .animating > .dropdown-content {
         overflow: hidden;
         will-change: transform;
         contain: content;
@@ -102,27 +104,23 @@ Custom property | Description | Default
         animation-timing-function: step-end;
       }
 
-      .entry-animation {
-        animation-delay: 100ms;
-        animation-duration: 275ms;
+      .animating {
         animation-name: expand-animation;
       }
 
-      .entry-animation > * {
+      .animating > .dropdown-content {
+        animation-name: expand-animationInverse;
+      }
+
+      .entry-animation,
+      .entry-animation > .dropdown-content {
         animation-delay: 100ms;
         animation-duration: 275ms;
-        animation-name: expand-animationInverse;
       }
 
-      .exit-animation {
+      .exit-animation,
+      .exit-animation > .dropdown-content {
         animation-duration: 200ms;
-        animation-name: expand-animation;
-        animation-direction: reverse;
-      }
-
-      .exit-animation > * {
-        animation-duration: 200ms;
-        animation-name: expand-animationInverse;
         animation-direction: reverse;
       }
 
@@ -246,7 +244,6 @@ Custom property | Description | Default
           transform: scale(1, 1);
         }
       }
-
     </style>
 
     <div id="trigger" on-tap="toggle">
@@ -395,28 +392,6 @@ Custom property | Description | Default
           closeOnActivate: {
             type: Boolean,
             value: false
-          },
-
-          /**
-           * This property is deprecated and will be ignored.
-           * @deprecated
-           */
-          openAnimationConfig: {
-            type: Object,
-            value: function() {
-              return [];
-            }
-          },
-
-          /**
-           * This property is deprecated and will be ignored.
-           * @deprecated
-           */
-          closeAnimationConfig: {
-            type: Object,
-            value: function() {
-              return [];
-            }
           },
 
           /**


### PR DESCRIPTION
Remove neon-animation dependency in favor of CSS keyframe animations, taking a similar approach as in https://github.com/PolymerElements/iron-dropdown/pull/154 and PolymerElements/paper-dialog#163.

The expand/collapse animation is done in a performant way using `transform`, which doesn't cause layout thrashing - more details here https://medium.com/@valdrinkoshi/performant-expand-collapse-animations-93d99e80f7f

This is technically a breaking change, as it removes the properties `openAnimationConfig` and `closeAnimationConfig`. This is done mainly because `paper-menu-button` cannot really allow users to define animations for its internal `iron-dropdown`, as there is no way to pass `@keyframes` into a shadowRoot.

Nevertheless, after testing this on internal projects it doesn't break them - as most of them rely on the default animations setup by paper-menu-button.