### PR TITLE
Fix #101 - Make restoreFocusOnClose false by default

### DIFF
--- a/paper-menu-button.html
+++ b/paper-menu-button.html
@@ -292,7 +292,7 @@ Custom property | Description | Default
         /**
          * Whether focus should be restored to the button when the menu closes.
          */
-        restoreFocusOnClose: {type: Boolean, value: true},
+        restoreFocusOnClose: {type: Boolean, value: false},
 
         /**
          * This is the element intended to be bound as the focus target


### PR DESCRIPTION
As stated in title.

This will allow setting the restoreFocusOnClose property via markup