### PR TITLE
Fix #101 (for 3.0.x) - Make restoreFocusOnClose false by default

### DIFF
--- a/paper-menu-button.js
+++ b/paper-menu-button.js
@@ -276,7 +276,7 @@ export const PaperMenuButton = Polymer({
     /**
      * Whether focus should be restored to the button when the menu closes.
      */
-    restoreFocusOnClose: {type: Boolean, value: true},
+    restoreFocusOnClose: {type: Boolean, value: false},
 
     /**
      * This is the element intended to be bound as the focus target


### PR DESCRIPTION
As stated in title.

This will allow setting the restoreFocusOnClose property via markup