### PR TITLE
Explicitly set _template to null.

### DIFF
--- a/paper-menu-button-animations.js
+++ b/paper-menu-button-animations.js
@@ -14,6 +14,7 @@ import {NeonAnimationBehavior} from '@polymer/neon-animation/neon-animation-beha
 import {Polymer} from '@polymer/polymer/lib/legacy/polymer-fn.js';
 Polymer({
   is: 'paper-menu-grow-height-animation',
+  _template: null,
 
   behaviors: [NeonAnimationBehavior],
 


### PR DESCRIPTION
This lets us skip a querySelector on initial bootup, and makes this code compatible with strictTemplatePolicy.

Internalized as part of cl/218551336